### PR TITLE
aws-sam-translator 1.86.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
   run:
     - python
     - pydantic ==2.5.3
-    - boto3 >=1.5,<2.0a0
+    - boto3 >=1.19.5,<2.0a0
     - jsonschema >=3.2,<4.0a0
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - pip
     - setuptools
     - wheel
-    - pydantic ==2.5.3
   run:
     - python
     - pydantic ==2.5.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.38.0" %}
+{% set version = "1.86.0" %}
 
 package:
   name: aws-sam-translator
@@ -6,21 +6,23 @@ package:
 
 source:
   url: https://pypi.io/packages/source/a/aws-sam-translator/aws-sam-translator-{{ version }}.tar.gz
-  sha256: 0ecadda9cf5ab2318f57f1253181a2151e4c53cd35d21717a923c075a5a65cb6
+  sha256: a748dcd7886024cb7586abbbdbabe8c787c44c6547bb6602879d7bb8a6934d05
 
 build:
   noarch: python
   number: 1
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
     - setuptools
     - wheel
+    - pydantic ==2.5.3
   run:
-    - python >=3.6
+    - pydantic ==2.5.3
+    - python
     - boto3 >=1.5,<2.0a0
     - jsonschema >=3.2,<4.0a0
     - six >=1.15,<2.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+  skip: True # [py<38]
 
 requirements:
   host:
@@ -20,7 +21,7 @@ requirements:
     - wheel
   run:
     - python
-    - typing-extensions >=4.4 # [py==38]
+    - typing-extensions >=4.4
     - pydantic >=1.8,<3
     - boto3 >=1.19.5,<2.0a0
     - jsonschema >=3.2,<5.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,9 +20,11 @@ requirements:
     - wheel
   run:
     - python
-    - pydantic >=1.8,<3
-    - boto3 >=1.19.5,<2.0a0
-    - jsonschema >=3.2,<4.0a0
+    - typing-extensions >=4.4 # [py==38]
+    - pydantic ==2.5.3
+    - boto3 >=1.5,<2.0a0
+    - jsonschema >=3.2,<5.0a0
+    - six >=1.15,<2.0a0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - wheel
   run:
     - python
-    - pydantic ==2.5.3
+    - pydantic >=1.8,<3
     - boto3 >=1.19.5,<2.0a0
     - jsonschema >=3.2,<4.0a0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,6 @@ requirements:
     - pydantic >=1.8,<3
     - boto3 >=1.19.5,<2.0a0
     - jsonschema >=3.2,<5.0a0
-    - six >=1.15,<2.0a0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,8 @@ requirements:
     - wheel
     - pydantic ==2.5.3
   run:
-    - pydantic ==2.5.3
     - python
+    - pydantic ==2.5.3
     - boto3 >=1.5,<2.0a0
     - jsonschema >=3.2,<4.0a0
     - six >=1.15,<2.0a0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,8 +21,8 @@ requirements:
   run:
     - python
     - typing-extensions >=4.4 # [py==38]
-    - pydantic ==2.5.3
-    - boto3 >=1.5,<2.0a0
+    - pydantic >=1.8,<3
+    - boto3 >=1.19.5,<2.0a0
     - jsonschema >=3.2,<5.0a0
     - six >=1.15,<2.0a0
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - pydantic ==2.5.3
     - boto3 >=1.5,<2.0a0
     - jsonschema >=3.2,<4.0a0
-    - six >=1.15,<2.0a0
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,6 @@ source:
   sha256: a748dcd7886024cb7586abbbdbabe8c787c44c6547bb6602879d7bb8a6934d05
 
 build:
-  noarch: python
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:


### PR DESCRIPTION
aws-sam-translator 1.86.0

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/awslabs/serverless-application-model)
- Relevant dependency PRs:
  - cfn-lint

### Explanation of changes:

- Update version number
- Add pydantic
- `--no-build-isolation` 
