### PR TITLE
aws-sam-translator 1.111.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-sam-translator" %}
-{% set version = "1.110.0" %}
+{% set version = "1.111.0" %}
 
 package:
   name: {{ name }}
@@ -7,9 +7,9 @@ package:
 
 source:
   - url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
-    sha256: 466ee0e8200992c51b7fd5ede5e56ca2e8dd5473cc551e8495c14f2f4d636127
+    sha256: 6884d94e28dc20384e5e0396e9386a456fe59303d706924deb2646329b4d97d3
   - url: https://github.com/awslabs/serverless-application-model/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 97a81bbad6816d293939bd3b0fe27875f8e9363314f937be2c210741dcbdeaec
+    sha256: 3c99b306dae4c6ad290a1d87ad0716d354e51203967f137379cd3b5a9ae8ddd8
     folder: tests_src
 
 build:


### PR DESCRIPTION
## Bump aws-sam-translator to 1.111.0

### Links
- Jira Ticket: [PKG-17132](https://anaconda.atlassian.net/browse/PKG-17132)
- Dev URL: [github.com/awslabs/serverless-application-model](https://github.com/awslabs/serverless-application-model/tree/v1.111.0)
- conda-forge Recipe: [conda-forge/aws-sam-translator-feedstock](https://github.com/conda-forge/aws-sam-translator-feedstock)
- PyPI: [pypi.org/project/aws-sam-translator/1.111.0](https://pypi.org/project/aws-sam-translator/1.111.0/)
- PyPI Inspector: [inspector.pypi.io/project/aws-sam-translator/1.111.0](https://inspector.pypi.io/project/aws-sam-translator/1.111.0/)

### Changes
- `recipe/meta.yaml`: bumped version 1.110.0 → 1.111.0, updated sha256 for both the PyPI sdist and GitHub tests source


[PKG-17132]: https://anaconda.atlassian.net/browse/PKG-17132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ